### PR TITLE
Add websearch backend test and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,39 @@ az webapp log tail --name $FUNCTION_APP_NAME --resource-group $RESOURCE_GROUP
 azd deploy
 ```
 
+## Testing the Websearch function
+
+The repository includes an integration test (`tests/websearch_test.py`) that
+calls a SearXNG/Azure Function backend via HTTP. You can perform the same call
+manually with `curl`.
+
+### Local function
+
+```bash
+curl -X POST http://localhost:7071/api/websearch \
+  -H "Content-Type: application/json" \
+  -H "x-functions-key: $WEBSEARCH_FUNCTION_KEY" \
+  -d '{"query": "Microsoft Azure"}'
+```
+
+### Deployed function
+
+```bash
+curl -X POST https://<funcappname>.azurewebsites.net/api/websearch \
+  -H "Content-Type: application/json" \
+  -H "x-functions-key: $WEBSEARCH_FUNCTION_KEY" \
+  -d '{"query": "Microsoft Azure"}'
+```
+
+Set the `WEBSEARCH_FUNCTION_URL` and `WEBSEARCH_FUNCTION_KEY` environment
+variables before running the automated test:
+
+```bash
+WEBSEARCH_FUNCTION_URL=https://<funcappname>.azurewebsites.net/api/websearch \
+WEBSEARCH_FUNCTION_KEY=<key> \
+pytest tests/websearch_test.py
+```
+
 ## Source Code
 
 The function code for each MCP tool is defined in the Python files in the `src` directory. Functions are exposed as MCP tools using the `@app.generic_trigger` decorator.

--- a/tests/websearch_test.py
+++ b/tests/websearch_test.py
@@ -1,0 +1,20 @@
+import os
+import requests
+import pytest
+
+
+def test_websearch_backend():
+    """Test the websearch backend via its HTTP interface."""
+    url = os.environ.get("WEBSEARCH_FUNCTION_URL")
+    key = os.environ.get("WEBSEARCH_FUNCTION_KEY")
+    if not url or not key:
+        pytest.skip("WEBSEARCH_FUNCTION_URL and WEBSEARCH_FUNCTION_KEY must be set")
+
+    headers = {"x-functions-key": key, "Content-Type": "application/json"}
+    payload = {"query": "Microsoft Azure"}
+
+    response = requests.post(url, headers=headers, json=payload, timeout=15)
+    response.raise_for_status()
+
+    data = response.json()
+    assert data, "Empty JSON response"


### PR DESCRIPTION
## Summary
- add websearch integration test hitting backend using `WEBSEARCH_FUNCTION_URL` and `WEBSEARCH_FUNCTION_KEY`
- document `curl` examples for local and remote websearch endpoints in README

## Testing
- `pytest tests/websearch_test.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a61f36228083288ed5460f59029357