### PR TITLE
Remove unused docx2pdf dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ See [mcp-tools-list.txt](mcp-tools-list.txt) for an up-to-date list.
 
 ## Microsoft Entra application permissions (Graph)
 
-For the Word → PDF conversion via Microsoft Graph and SharePoint, create an app registration in Microsoft Entra ID and grant the following Application permissions (admin consent required):
+For the Word → PDF conversion via Microsoft Graph and SharePoint, create an app registration in Microsoft Entra ID and grant the following Application permissions (admin consent required). This approach does not require the `docx2pdf` library:
 
 - Files.ReadWrite.All
 - Sites.ReadWrite.All

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -5,7 +5,6 @@
 azure-functions
 python-docx
 azure-storage-blob
-docx2pdf
 msal
 requests
 requests-toolbelt


### PR DESCRIPTION
## Summary
- remove unused docx2pdf dependency from requirements
- clarify in docs that Word-to-PDF conversion uses Microsoft Graph

## Testing
- `python -m pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a61f46c6648328a51fc2cf7203c3cd